### PR TITLE
Add USE_FC_LEN_T

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ipfp
 Type: Package
 Title: Fast Implementation of the Iterative Proportional Fitting Procedure in C
-Version: 1.0.1
+Version: 1.0.2
 Author: Alexander W Blocker
 Maintainer: Alexander W Blocker <ablocker@gmail.com>
 Description: A fast (C) implementation of the iterative proportional fitting

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.0.2
 Author: Alexander W Blocker
 Maintainer: Alexander W Blocker <ablocker@gmail.com>
 Description: A fast (C) implementation of the iterative proportional fitting
-    procedure. Based on corresponding code from the networkTomography package.
+    procedure.
 License: Apache License (== 2.0)
 LazyLoad: yes
 URL: https://github.com/awblocker/ipfp

--- a/src/ipfp.c
+++ b/src/ipfp.c
@@ -1,4 +1,4 @@
-// Copyright 2012 Alexander W Blocker
+// Copyright 2022 Alexander W Blocker
 //    
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#define USE_FC_LEN_T
+
 #include <R.h>
 #include <Rinternals.h>
 #include <Rmath.h>
@@ -21,6 +23,10 @@
 #include <math.h>
 #include <assert.h>
 #include <stdlib.h>
+
+#ifndef FCONE
+# define FCONE
+#endif
 
 /* Function to calculate scalar product z = x * y */
 void vecProduct(int n, double * x, int incx, double * y, int incy,

--- a/src/ipfp.c
+++ b/src/ipfp.c
@@ -102,7 +102,7 @@ SEXP ipfp (SEXP y, SEXP A, SEXP dims, SEXP x,
     	alpha = 1;
     	beta = -1;
     	dgemv_(&notrans, &nrow, &ncol, &alpha, &REAL(A)[0], &nrow,
-    			&REAL(xx)[0], &incx, &beta, errVec, &incx);
+    			&REAL(xx)[0], &incx, &beta, errVec, &incx FCONE);
 
     	// Calculate L2 norm of err
     	errNorm = dnrm2_(&nrow, errVec, &incx);


### PR DESCRIPTION
Following guidance from https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Fortran-character-strings and the following note:

> This is a mechanism introduced in R 3.6.2 to change the C/C++ prototypes
of BLAS and LAPACK functions to correspond to code produced by gfortran
 >= 7.  Now that compiler is in near-universal use, it is planned to
make its use obligatory in R 4.2.0, with the switch in R-devel in early
November.
>
> The documentation is in `Writing R Extensions' §6.6.2,
https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Fortran-character-strings
. Note the caveats: USE_FC_LEN_T has to be defined before any R headers
are included.